### PR TITLE
Allow specifying a timeout when checking for Unreal services

### DIFF
--- a/src/unreal_interface_py/object.py
+++ b/src/unreal_interface_py/object.py
@@ -98,7 +98,7 @@ class Object:
         self.init()
         self.logger = logging.getLogger(__name__)
 
-    def transport_available(self):
+    def transport_available(self, timeout=TRANSPORT_CHECK_TIMEOUT_TIME):
         """
         Use this method to do a low-level functional check of the transport capabilities.
         In the current version of this library, this method is checking if the necessary
@@ -106,11 +106,11 @@ class Object:
         :return: True if necessary services are available and the corresponding ServiceProxys are up
         """
         try:
-            rospy.wait_for_service(self.spawn_client.resolved_name, timeout=TRANSPORT_CHECK_TIMEOUT_TIME)
-            rospy.wait_for_service(self.delete_client.resolved_name, timeout=TRANSPORT_CHECK_TIMEOUT_TIME)
-            rospy.wait_for_service(self.delete_all_client.resolved_name, timeout=TRANSPORT_CHECK_TIMEOUT_TIME)
-            rospy.wait_for_service(self.set_pose_client.resolved_name, timeout=TRANSPORT_CHECK_TIMEOUT_TIME)
-            rospy.wait_for_service(self.get_pose_client.resolved_name, timeout=TRANSPORT_CHECK_TIMEOUT_TIME)
+            rospy.wait_for_service(self.spawn_client.resolved_name, timeout=timeout)
+            rospy.wait_for_service(self.delete_client.resolved_name, timeout=timeout)
+            rospy.wait_for_service(self.delete_all_client.resolved_name, timeout=timeout)
+            rospy.wait_for_service(self.set_pose_client.resolved_name, timeout=timeout)
+            rospy.wait_for_service(self.get_pose_client.resolved_name, timeout=timeout)
 
         except Exception as e:
             self.logger.info(f"Exception catched in transport_available(): {e}")


### PR DESCRIPTION
In a specific project configuration I want to start all ROS components from a single launch file. That means the launch file must be started before the Unreal instance is up, since otherwise Unreal will not find the required rosbridge endpoints. If I do that, then another component that uses this interface to talk to Unreal dies because of the hardcoded 0.3 second timeout.

With this change, I can specify a longer timeout so that I can manually bring up Unreal in time.